### PR TITLE
Add downloaded wal-g file check and some other adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ walg_version: 0.2.15
 # wal-g releases repository url
 walg_url: "https://github.com/wal-g/wal-g/releases/download/v{{ walg_version }}/wal-g.linux-amd64.tar.gz"
 
+# wal-g download checksum (get it from the release page or directly from : "{{ walg_url }}.sha256")
+walg_sha256_checksum:
+
 # wal-g binary place
 walg_binary: /usr/local/bin/wal-g
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 
 walg_version: 0.2.15
 walg_url: "https://github.com/wal-g/wal-g/releases/download/v{{ walg_version }}/wal-g.linux-amd64.tar.gz"
+walg_sha256_checksum: ea33c2341d7bfb203c6948590c29834c013ab06a28c7a2b236a73d906f785c84
 walg_binary: /usr/local/bin/wal-g
 
 walg_user: postgres

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,6 @@
     path: "{{ walg_binary }}"
   register: walg_current_binary
   changed_when: false
-  tags:
-    - always
 
 - name: wal-g | get current binary version
   shell: |
@@ -19,8 +17,6 @@
   check_mode: false
   when:
     - walg_current_binary.stat.exists
-  tags:
-    - always
 
 - name: wal-g | download when upgrade or downgrade
   ansible.builtin.get_url:
@@ -46,8 +42,6 @@
     - walg_binary_extracted_name: "{{ walg_url | basename | replace('.tar.gz', '') }}"
   when:
     - not walg_current_binary.stat.exists or walg_current_version.stdout is version(walg_version, '!=')
-  tags:
-    - always
 
 - name: wal-g | combine env config
   block:
@@ -69,16 +63,12 @@
         walg_postgresql_combine: "{{ walg_postgresql_config | combine(walg_postgresql_override) | dict2items(key_name='option', value_name='value') }}"
     - set_fact:
         walg_common_combine: "{{ walg_common_config | combine(walg_common_override) | dict2items(key_name='option', value_name='value') }}"
-  tags:
-    - always
 
 - name: wal-g | check env directory
   file:
     path: "{{ walg_env | dirname }}"
     state: directory
     mode: 0755
-  tags:
-    - always
 
 - name: wal-g | create env file
   template:
@@ -87,16 +77,12 @@
     owner: root
     group: adm
     mode: 0644
-  tags:
-    - always
 
 - name: wal-g | check scripts directory
   file:
     path: "{{ walg_script_path }}"
     state: directory
     mode: 0755
-  tags:
-    - always
 
 - name: wal-g | create scripts files
   template:
@@ -108,8 +94,6 @@
     mode: 0755
   with_fileglob:
     - ../templates/*.sh.j2
-  tags:
-    - always
 
 - name: wal-g | create cron job for create backups
   cron:
@@ -119,8 +103,6 @@
     user: "{{ walg_user }}"
     job: "{{ walg_script_path }}/walg-backup.sh"
     state: "{{ walg_cron_enabled | ternary('present', 'absent') }}"
-  tags:
-    - always
 
 - name: wal-g | create cron job for rotate backups
   cron:
@@ -130,5 +112,3 @@
     user: "{{ walg_user }}"
     job: "{{ walg_script_path }}/walg-rotate.sh"
     state: "{{ walg_cron_enabled | ternary('present', 'absent') }}"
-  tags:
-    - always

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,18 +22,28 @@
   tags:
     - always
 
-- name: wal-g | download with unarchive when upgrade or downgrade
+- name: wal-g | download when upgrade or downgrade
+  ansible.builtin.get_url:
+    url: "{{ walg_url }}"
+    dest: /tmp/{{ walg_url | basename }}
+    checksum: sha256:{{ walg_sha256_checksum }}
+  when:
+    - not walg_current_binary.stat.exists or walg_current_version.stdout is version(walg_version, '!=')
+
+- name: wal-g | unarchive when upgrade or downgrade
   unarchive:
-    src: "{{ walg_url }}"
+    src: /tmp/{{ walg_url | basename }}
     dest: "{{ walg_binary | dirname }}"
-    exclude:
-      - 'README.md'
-      - 'LICENSE'
+    include: "{{ walg_binary_extracted_name }}"
+    extra_opts:
+    - --transform
+    - "{{ 's/^' + walg_binary_extracted_name + '$/wal-g/' }}"
     remote_src: true
-    force: true
     owner: root
     group: root
-    mode: 0755
+    mode: "755"
+  vars:
+    - walg_binary_extracted_name: "{{ walg_url | basename | replace('.tar.gz', '') }}"
   when:
     - not walg_current_binary.stat.exists or walg_current_version.stdout is version(walg_version, '!=')
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
   file:
     path: "{{ walg_env | dirname }}"
     state: directory
-    mode: 0755
+    mode: "755"
 
 - name: wal-g | create env file
   template:
@@ -76,13 +76,13 @@
     dest: "{{ walg_env }}"
     owner: root
     group: adm
-    mode: 0644
+    mode: "644"
 
 - name: wal-g | check scripts directory
   file:
     path: "{{ walg_script_path }}"
     state: directory
-    mode: 0755
+    mode: "755"
 
 - name: wal-g | create scripts files
   template:
@@ -91,7 +91,7 @@
     backup: no
     owner: root
     group: adm
-    mode: 0755
+    mode: "755"
   with_fileglob:
     - ../templates/*.sh.j2
 


### PR DESCRIPTION
## Description

- Add wal-g download checksum check to avoid installing a corrupted or altered version. Moreover, the unarchiving task is adapted to the fact that the files included in the tar.gz of recent versions of wal-g have changed compared to older versions.
- Remove wal-g `always` ansible tags because we don't want ansible to always execute the wal-g role if we are targeting another role of the playbook.
- Set files's mode as advised by the [ansible documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-mode).

## Tests
- Change the wal-g version to upgrade or downgrade it while replacing the corresponding sha256 checksum, then validate that the desired version is correctly downloaded and installed.
- Repeat the same test but without updating the checksum and validate that an ansible error is thrown.
- Run ansible on a different tag than the one used to include the wal-g role and validate that the wal-g role is no longer executed.